### PR TITLE
Handle incorrectly formatted dates

### DIFF
--- a/ckanext/dgu/lib/helpers.py
+++ b/ckanext/dgu/lib/helpers.py
@@ -1907,6 +1907,11 @@ def relative_url_for(**kwargs):
     return h.url_for(**args)
 
 def parse_date(date_string):
-    from ckan.lib.field_types import DateType
+    from ckan.lib.field_types import DateType, DateConvertError
 
-    return DateType.parse_timedate(date_string, 'form')
+    try:
+        return DateType.parse_timedate(date_string, 'form')
+    except DateConvertError:
+        class FakeDate:
+            year = ''
+        return FakeDate()


### PR DESCRIPTION
Simple fix so that all items with dates that do not parse will get grouped together.
