### PR TITLE
Handle multiple signatures

### DIFF
--- a/ckanext/dgu/theme/templates/_dgu_util.html
+++ b/ckanext/dgu/theme/templates/_dgu_util.html
@@ -13,7 +13,7 @@
     <py:with vars="
       page=pageobj.page;
       numpages=pageobj.page_count;
-      url_for_page=lambda x:pageobj._url_generator(x)
+      url_for_page=lambda x:pageobj._url_generator(page=x)
     ">
     <div class="dgu-pagination" py:if="numpages>1">
       <ul class="pagination">


### PR DESCRIPTION
Because the function being called could have one of two signatures this fix
calls the function using a named argument which should be compatible with both.
