### PR TITLE
Direct new publishers to the contact page

### DIFF
--- a/ckanext/dgu/theme/templates/publisher/index.html
+++ b/ckanext/dgu/theme/templates/publisher/index.html
@@ -14,7 +14,7 @@
     <p>Datasets are 'published' on data.gov.uk by a range of organisations, mainly from the public sector. On this page you can browse and search for them by name or place in a notional hierarchy.</p>
     <div py:if="c.userobj" class="panel panel-info">
       <div class="panel-heading"><strong>Adding New Publishers</strong></div>
-      <div class="panel-body">If you are from a public sector body not listed yet, please <a href="/publisher/apply/cabinet-office">get in touch with Cabinet Office data.gov.uk team</a> to request the addition of your publisher</div>
+      <div class="panel-body">If you are from a public sector body not listed yet, please <a href="/contact">get in touch with Cabinet Office data.gov.uk team</a> to request the addition of your publisher</div>
     </div>
     <div class="search-area" style="margin-top: 20px; margin-bottom: 30px;">
       <div class="clearfix dgu-equal-height" data-selector=".auto-height">


### PR DESCRIPTION
Instead of the current link to apply to be a editor of the Cabinet Office
publisher.
