### PR TITLE
[noticket] Fix double quoting error

### DIFF
--- a/ckanext/dgu/theme/templates/package/read.html
+++ b/ckanext/dgu/theme/templates/package/read.html
@@ -147,7 +147,7 @@
     <h2>Related Applications</h2>
     <ul>
       <li py:for="rel in h.get_related_apps(c.pkg_dict.get('id'))">
-        <a href="${rel.url}">${rel.title}</a>
+        <a href="${rel.url}">${h.literal(rel.title)}</a>
       </li>
     </ul>
     </py:if>


### PR DESCRIPTION
App titles we get from the API are already quoted so when Genshi quotes them
again we get things like `&amp;amp;`
