### PR TITLE
[1612] Remove sysadmins who have been added as publisher admins

### DIFF
--- a/ckanext/dgu/bin/remove_admins_from_publishers.py
+++ b/ckanext/dgu/bin/remove_admins_from_publishers.py
@@ -1,0 +1,40 @@
+'''Tool that removes all sysadmins as admins of publishers
+'''
+import sys
+
+from ckanext.dgu.bin import common
+from ckanext.dgu.bin.running_stats import StatsList
+
+
+def remove_admins():
+    from ckan import model
+
+    admin_ids = [i[0] for i in model.Session.query(model.User.id).filter_by(sysadmin=True).all()]
+
+    members = model.Session.query(model.Member)\
+                .filter_by(table_name='user', capacity='admin', state='active')\
+                .filter(model.Member.table_id.in_(admin_ids))
+
+    print "There are %s memberships to be deleted" % members.count()
+
+    members.update({'state': 'deleted'}, synchronize_session='fetch')
+
+    model.Session.commit()
+
+
+if __name__ == '__main__':
+    usage = __doc__ + """
+usage:
+
+%prog <ckan.ini>
+"""
+    if len(sys.argv) < 2:
+        print usage
+        sys.exit("Wrong number of args")
+    config_filepath = sys.argv[1]
+    print 'Loading CKAN config...'
+    common.load_config(config_filepath)
+    common.register_translator()
+    print 'Done'
+    remove_admins()
+


### PR DESCRIPTION
I think this only needs to be run once after https://github.com/datagovuk/ckan/pull/3 has been deployed.
