### PR TITLE
Unescape HTML when importing related apps

### DIFF
--- a/ckanext/dgu/commands/appsync.py
+++ b/ckanext/dgu/commands/appsync.py
@@ -2,6 +2,7 @@ import json
 import logging
 import lxml.html
 from urlparse import urljoin
+from HTMLParser import HTMLParser
 from collections import defaultdict
 
 import requests
@@ -140,9 +141,11 @@ class AppSync(CkanCommand):
     def _add_related(self, package, app_title, app_url, image_url=''):
         stats.add("Adding related item", "[%s] -> [%s]" % (package.name, app_title))
 
+        html_parser = HTMLParser()
+
         related = model.Related()
         related.type = 'App'
-        related.title = app_title
+        related.title = html_parser.unescape(app_title)
         related.description = ""
         related.url = app_url
 

--- a/ckanext/dgu/theme/templates/package/read.html
+++ b/ckanext/dgu/theme/templates/package/read.html
@@ -147,7 +147,7 @@
     <h2>Related Applications</h2>
     <ul>
       <li py:for="rel in h.get_related_apps(c.pkg_dict.get('id'))">
-        <a href="${rel.url}">${h.literal(rel.title)}</a>
+        <a href="${rel.url}">${rel.title}</a>
       </li>
     </ul>
     </py:if>


### PR DESCRIPTION
As requested I've updated this so that it unquotes the HTML when importing from the API.

After this is deployed to live we will need to remove all of the related items from the database and run the sync again. The SQL is:

```
TRUNCATE related CASCADE;
```

I have already deployed this change to the staging server.
