### PR TITLE
[1623] Make URL protocol relative earlier

### DIFF
--- a/ckanext/dgu/commands/appsync.py
+++ b/ckanext/dgu/commands/appsync.py
@@ -115,6 +115,8 @@ class AppSync(CkanCommand):
                 continue
 
             related_url = urljoin(root_url, d['path'])
+            related_url = re.sub('^https*:', '', related_url)
+
             thumb = d.get('thumbnail', '').replace("://", "/")
             if thumb:
                 thumb_url = urljoin(root_url, "/sites/default/files/styles/medium/")
@@ -148,7 +150,6 @@ class AppSync(CkanCommand):
         related.type = 'App'
         related.title = html_parser.unescape(app_title)
         related.description = ""
-        related.url = re.sub('^https*:', '', app_url)
 
         related.image_url = image_url
 


### PR DESCRIPTION
So that we are comparing the same type of URL as has been stored in the
database.

Once this has been merged we will have to clear out the related and related_datasets tables and run the import again.
