### PR TITLE
admin_editor report should return 404 for a bad org name

### DIFF
--- a/ckanext/dgu/lib/reports.py
+++ b/ckanext/dgu/lib/reports.py
@@ -563,7 +563,9 @@ def admin_editor(org=None, include_sub_organizations=False):
 
     if org:
         q = model.Group.all('organization')
-        parent = model.Session.query(model.Group).filter_by(name=org).one()
+        parent = model.Group.by_name(org)
+        if not parent:
+            raise p.toolkit.ObjectNotFound('Publisher not found')
 
         if include_sub_organizations:
             child_ids = [ch[0] for ch in parent.get_children_group_hierarchy(type='organization')]
@@ -642,7 +644,11 @@ def admin_editor_authorize(user, options):
 
     if options.get('org', False):
         org_name = options["org"]
-        org = model.Session.query(model.Group).filter_by(name=org_name).one()
+        org = model.Session.query(model.Group) \
+                   .filter_by(name=org_name) \
+                   .first()
+        if not org:
+            return False
 
         if user_is_admin(user, org) or user_is_rm(user, org):
             return True


### PR DESCRIPTION
admin_editor report should return 404 when a bad org name is supplied, rather than an uncaught exception. Example url: /data/report/admin_editor?org=rubbish