### PR TITLE
Fix API link in footer.html

### DIFF
--- a/ckanext/dgu/theme/templates/footer.html
+++ b/ckanext/dgu/theme/templates/footer.html
@@ -10,7 +10,7 @@
         <li class="menu-536"><a href="/moderation-policy">Moderation policy</a></li>
         <li class="menu-520"><a href="/contact" title="">Contact</a></li>
         <li class="menu-538 "><a href="/terms-and-conditions">Terms and conditions</a></li>
-        <li class="menu-538"><a href="/about">API</a></li>
+        <li class="menu-538"><a href="/data/api">API</a></li>
         <li class="menu-538 last"><a href="/about">About</a></li>
       </ul>
       <div class="credits">


### PR DESCRIPTION
The link in Drupal and the link in CKAN are inconsistent.

See [this](http://data.gov.uk/search/everything) page and [this](http://data.gov.uk/data/search) one.

Greetings from Romania. :smile: 