### PR TITLE
[1891] Dont show the format of Additional Resources in the search results

### DIFF
--- a/ckanext/dgu/lib/helpers.py
+++ b/ckanext/dgu/lib/helpers.py
@@ -672,9 +672,11 @@ def package_publisher_dict(package):
 
 
 def formats_for_package(package):
-    formats = [ x.get('format','').strip().lower() for x in package.get('resources',[])]
+    formats = [res.get('format', '').strip().lower()
+               for res in package.get('resources', [])
+               if res.get('resource_type') != 'documentation']
     # Strip empty strings, deduplicate and sort
-    formats = filter(bool,formats)
+    formats = filter(bool, formats)
     formats = set(formats)
     formats = sorted(list(formats))
     return formats


### PR DESCRIPTION
Goes with commit on core ckan which stops docs being indexed:
https://github.com/datagovuk/ckan/commit/aecbaac6596d45bf2995297e84b032be3184dfc3