### PR TITLE
Add a new page just containing links to each dataset 

### DIFF
--- a/ckanext/dgu/controllers/package.py
+++ b/ckanext/dgu/controllers/package.py
@@ -26,6 +26,19 @@ class PackageController(ckan.controllers.package.PackageController):
             abort(401, 'Log-in to see this page')
         return super(PackageController, self).history(id)
 
+    def all_packages(self):
+
+        ctx = {'model': model, 'session': model.Session}
+        package_list = get_action("package_list")(ctx, {})
+
+        def linkify_packages(pkgs):
+            x = 0
+            for pkg in pkgs:
+                yield '<a href="/dataset/{p}">{p}</a><br/>'.format(p=pkg)
+
+        c.datasets = linkify_packages(package_list)
+        return render("package/all_datasets.html")
+
     def delete(self, id):
         """Provide a delete ('withdraw') action, but only for UKLP datasets"""
         from ckan.lib.search import SearchIndexError

--- a/ckanext/dgu/plugin.py
+++ b/ckanext/dgu/plugin.py
@@ -226,6 +226,9 @@ class ThemePlugin(p.SingletonPlugin):
 
         map.redirect('/dashboard', '/data/user/me')
 
+        dgu_package_controller = 'ckanext.dgu.controllers.package:PackageController'
+        map.connect('all_dataset_list', '/data/_all_datasets_', controller=dgu_package_controller, action='all_packages')
+
         return map
 
     def after_map(self, map):

--- a/ckanext/dgu/theme/templates/package/all_datasets.html
+++ b/ckanext/dgu/theme/templates/package/all_datasets.html
@@ -1,0 +1,15 @@
+{% extends "page.html" %}
+
+{% block title %}All Datasets{% endblock %}
+
+{% block breadcrumb_content %}
+  {{ h.build_nav('dgu_search', _('Datasets')) }}
+{% endblock %}
+
+{% block primary_content %}
+
+    {% for dataset in c.datasets %}
+        {{dataset|safe}}
+    {% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
This is so that we have a page where we can point wget to spider all of the datasets, and avoid wgetting anything under /data/search...