### PR TITLE
Fix issue that was causing secondary theme corruption

### DIFF
--- a/ckanext/dgu/lib/helpers.py
+++ b/ckanext/dgu/lib/helpers.py
@@ -640,6 +640,16 @@ def json_list(json_str):
         return obj.items()
     # json can't be anything else
 
+def list_flatten(data):
+    '''
+    If data is a list flatten it,
+    otherwise return input data
+    '''
+    if isinstance(data, list):
+        return ", ".join(data)
+    else:
+        return data
+
 def dgu_format_icon(format_string):
     fmt = formats.Formats.match(format_string.strip().lower())
     icon_name = 'document'

--- a/ckanext/dgu/theme/src/scripts/dgu-package-form.js
+++ b/ckanext/dgu/theme/src/scripts/dgu-package-form.js
@@ -251,7 +251,7 @@
 
             var secondaries = obj.result['secondary-theme'];
             var all_reasons = [];
-            for (var i = 0; i < secondaries.length; i++ ) {
+            for (var i = 0; i < secondaries.length; i++) {
                 var th = secondaries[i].name;
                 nm = nm + th;
                 if ( i != secondaries.length-1 ) {

--- a/ckanext/dgu/theme/templates/package/edit_form.html
+++ b/ckanext/dgu/theme/templates/package/edit_form.html
@@ -413,9 +413,9 @@ Passed in:
 
   <div style="width: 45%; float: left; margin-right: 4%;">
     <label>Secondary themes</label>
-    <input type="hidden" id="theme-secondary" name="theme-secondary" value="{{ ','.join(data.get('theme-secondary', [])) }}"/>
+    <input type="hidden" id="theme-secondary" name="theme-secondary" value="{{ h.list_flatten(data.get('theme-secondary', '')) }}"/>
     <span id="theme-secondary-label">
-      {{ ','.join(data.get('theme-secondary', [])) or 'None' }}
+      {{ h.list_flatten(data.get('theme-secondary', 'None')) }}
     </span>
 
     <br/>


### PR DESCRIPTION
We store the secondary themes in the database as a JSON list of strings. This gets de-serialised, into a list, when coming out of the database for the package edit form. But when the package edit form is submitted with an error, the form is re-rendered using the submitted data which is a string of comma separated themes.

This change caters for the fact the secondary themes might be a list or (on submission error) it might be a string containing a comma separated list of themes.