### PR TITLE
[#170] Set the Content-Type header on cached resources

### DIFF
--- a/ckanext/dgu/controllers/data.py
+++ b/ckanext/dgu/controllers/data.py
@@ -279,9 +279,8 @@ class DataController(BaseController):
 
         file_size = os.path.getsize(filepath)
         if not is_html:
-            headers = [('Content-Type', content_type),
-                       ('Content-Length', str(file_size))]
-            fapp = FileApp(filepath, headers=headers)
+            headers = [('Content-Length', str(file_size))]
+            fapp = FileApp(filepath, headers=headers, content_type=content_type)
             return fapp(request.environ, self.start_response)
 
         origin = tidy_url(resource.url)

--- a/ckanext/dgu/controllers/data.py
+++ b/ckanext/dgu/controllers/data.py
@@ -265,7 +265,7 @@ class DataController(BaseController):
         # Make an attempt at getting the correct content type but fail with
         # application/octet-stream in cases where we don't know.
         formats = {
-            "CSV": "application/csv",
+            "CSV": "text/csv",
             "XLS": "application/vnd.ms-excel",
             "HTML": 'text/html; charset=utf-8' }
         content_type = formats.get(fmt, "application/octet-stream")


### PR DESCRIPTION
Unless the content_type kwarg is passed to the constructor FileApp will make a
guess at the Content-Type of the file.

Zip files need to be served as application/octet-stream to avoid IE 8 bug.

Fixes #170