### PR TITLE
Get rid of stray prints

### DIFF
--- a/ckanext/dgu/controllers/data.py
+++ b/ckanext/dgu/controllers/data.py
@@ -310,8 +310,6 @@ class DataController(BaseController):
 
         response.write(content)
 
-
-
     def viz_upload(self):
         """
         Provides direct upload to DGU for users in specific publishers.
@@ -382,10 +380,10 @@ class DataController(BaseController):
             pkg = get_action('package_show')(context, {'id': c.dataset})
             pkg['resources'].append(resource)
             res = get_action('package_update')(context, pkg)
-            print res
+            log.info('Added viz to dataset %s: %s', pkg['name'], resource)
 
             flash_success('The file has been uploaded and added to the dataset. <a href="/dataset/{}" style="text-decoration:underline;">View dataset</a>'.format(c.dataset), allow_html=True)
-            return redirect("/data/viz/upload")
+            return redirect('/data/viz/upload')
 
         return render('viz/upload.html')
 

--- a/ckanext/dgu/lib/ingest.py
+++ b/ckanext/dgu/lib/ingest.py
@@ -25,7 +25,8 @@ import logging
 import messytables
 import os
 
-log = logging.getLogger("ckanext")
+log = logging.getLogger(__name__)
+
 
 class IngestException(Exception):
     """
@@ -55,7 +56,7 @@ class Ingester(object):
             if str(e) == "Unrecognized MIME type: text/plain":
                 # Attempt to force the load as a CSV file to work around messytables
                 # not recognising text/plain
-                self.tableset = messytables.any_tableset(f, mimetype="text/csv")
+                self.tableset = messytables.any_tableset(filename, mimetype="text/csv")
             else:
                 log.exception(e)
                 raise Exception(u"Failed to load the file at {0}".format(filename))

--- a/ckanext/dgu/lib/ingest.py
+++ b/ckanext/dgu/lib/ingest.py
@@ -102,7 +102,7 @@ class Ingester(object):
                     count = count + 1
                 except IngestException, ie:
                     if ie.should_continue:
-                        print ie
+                        log.warning('Ingest error, but continuing: %s', ie)
                         continue
                     raise ie
 


### PR DESCRIPTION
Print statements might be the cause of "IOError: failed to write data" errors we see occasional on prod3. It's easy to miss these, since print is harmless when run in paster.