### PR TITLE
Make sure we don't send the data_dict in JSON response

### DIFF
--- a/ckanext/dgu/plugin.py
+++ b/ckanext/dgu/plugin.py
@@ -509,6 +509,8 @@ class SearchPlugin(p.SingletonPlugin):
         return search_params
 
     def after_search(self, search_results, search_params):
+        for r in search_results.get("results"):
+            del r['data_dict']
         return search_results
 
     def before_view(self, pkg_dict):

--- a/ckanext/dgu/plugin.py
+++ b/ckanext/dgu/plugin.py
@@ -509,7 +509,7 @@ class SearchPlugin(p.SingletonPlugin):
         return search_params
 
     def after_search(self, search_results, search_params):
-        for r in search_results.get("results"):
+        for r in search_results.get("results", []):
             del r['data_dict']
         return search_results
 


### PR DESCRIPTION
Previously when doing a search, the search results contained a data_dict
field containing the entire object as a JSON string.  This PR removes it
from the search results.

Our CKAN package_search just JSON encodes whatever it gets back from the SOLR query, and so this is the obvious place to fix it without changes to how our package_search works.

This fixes #213 