### PR TITLE
Give user the package_show API link, instead of RESTful interface

### DIFF
--- a/ckanext/dgu/theme/templates/data/api.html
+++ b/ckanext/dgu/theme/templates/data/api.html
@@ -3,15 +3,16 @@
 {% block title %}Data API{% endblock %}
 
 {% block breadcrumb_content %}
-  {{ h.build_nav('api_page', _('CKAN API')) }}
+  {{ h.build_nav('api_page', 'Metadata API') }}
 {% endblock %}
 
-<h1>Data Catalogue API</h1>
 
 {% block primary_content_inner %}
 
-    <h1>CKAN API Notes</h1>
-    <p>Developers can access the data catalogue with an API, as an alternative to the data.gov.uk web interface. The API provides both RESTful and functional interfaces, all in JSON format, making it suitable for a wide range of clients.</p>
+    <h1>Metadata API</h1>
+
+    <h3>CKAN API Notes</h3>
+    <p>Developers can access the data catalogue with the metadata API, as an alternative to the data.gov.uk web interface. The API provides both RESTful and functional interfaces, all in JSON format, making it suitable for a wide range of clients.</p>
 
     {% set url = g.site_url+('/' if g.site_url[-1]!='/' else '')+'api' %}
     <p>The base URL for the API is: <a href="{{url}}">{{url}}</a></p>

--- a/ckanext/dgu/theme/templates/package/read_common.html
+++ b/ckanext/dgu/theme/templates/package/read_common.html
@@ -48,7 +48,7 @@
             <p>The information on this page (the dataset metadata) is also available in JSON format.</p>
             <ul>
               <li>
-                <b><a href="{{h.url_for(controller='api', register='package', action='show', id=c.pkg.name, ver='2')}}"  target="_blank">Metadata JSON for this dataset</a></b>
+                <b><a href="{{h.url_for(controller='api', action='action', ver='3', id=c.pkg.name, logic_function='package_show')}}"  target="_blank">Metadata JSON for this dataset</a></b>
               </li>
               <li>
                 <b><a href="{{h.url_for(controller='ckanext.dgu.controllers.data:DataController', action='api')}}">


### PR DESCRIPTION
Also tidy wording of Metadata API page.