### PR TITLE
Fixes package form tests

### DIFF
--- a/ckanext/dgu/tests/__init__.py
+++ b/ckanext/dgu/tests/__init__.py
@@ -12,7 +12,6 @@ from ckanext.harvest.model import setup as harvest_setup
 # Invoke websetup with the current config file
 SetupCommand('setup-app').run([config['__file__']])
 
-
 class PackageFixturesBase:
     def create(self, **kwargs):
         CreateTestData.create_arbitrary(self.pkgs,

--- a/test-core.ini
+++ b/test-core.ini
@@ -22,7 +22,7 @@ use = config:../ckan/test-core.ini
 dgu.xmlrpc_username =
 dgu.xmlrpc_password =
 dgu.xmlrpc_domain = localhost:8051
-ckan.plugins = dgu_form dgu_auth_api dgu_publishers dgu_theme dgu_publisher_form dgu_dataset_form spatial_harvest_metadata_api dgu_api dgu_inventory dgu_search taxonomy
+ckan.plugins = dgu_form dgu_auth_api dgu_publishers dgu_theme dgu_publisher_form dgu_dataset_form spatial_harvest_metadata_api dgu_api dgu_inventory dgu_search taxonomy dgu_schema
 
 who.config_file = %(here)s/ckanext/dgu/who.ini
 search.facets = groups tags res_format license resource-type UKLP


### PR DESCRIPTION
A lot of tests were failing because of schema plugin/tables not being
present, and:

1. Testing theme editing no longer works, so removed.
2. Mandate editing has changed, so update the test to use form.get()
which is needed for when you have several elements with the same name.