### PR TITLE
Fix genshi to jinja2 bug in linked_user

### DIFF
--- a/ckanext/dgu/lib/helpers.py
+++ b/ckanext/dgu/lib/helpers.py
@@ -329,9 +329,7 @@ def user_link_info(user_name, organization=None):  # Overwrite h.linked_user
     user_name, user, user_drupal_id, type_, this_is_me = user_properties(user_name)
 
     # Now decide how to display the user
-    if c.is_an_official is '':
-        c.is_an_official = bool(c.groups or is_sysadmin())
-    if (c.is_an_official or this_is_me or type_ is None):
+    if (is_an_official() or this_is_me or type_ is None):
         # User can see the actual user name - i.e. if:
         # * viewer is an official
         # * viewing ones own user

--- a/ckanext/dgu/tests/lib/test_helpers.py
+++ b/ckanext/dgu/tests/lib/test_helpers.py
@@ -4,6 +4,7 @@ from nose.tools import assert_equal
 
 from ckan.tests.pylons_controller import PylonsTestCase
 import ckan.new_tests.factories as factories
+import ckan.new_tests.helpers as helpers
 from ckan import model
 
 from ckanext.dgu.testtools.create_test_data import DguCreateTestData
@@ -13,10 +14,33 @@ from ckanext.dgu.lib.helpers import (dgu_linked_user, user_properties,
                                      )
 from ckanext.dgu.plugins_toolkit import c, get_action
 
+from contextlib import contextmanager
+
+def regular_user():
+    return set_user_to('user')
+
+def publisher_user():
+    return set_user_to('co_editor')
+
+def sysadmin_user():
+    return set_user_to('sysadmin')
+
+@contextmanager
+def set_user_to(username):
+    old_user = c.userobj
+    c.userobj = model.User.by_name(username)
+
+    old_groups = c.groups
+    c.group = ''
+    yield
+    c.userobj = old_user
+    c.groups = old_groups
+
 
 class TestLinkedUser(PylonsTestCase):
     @classmethod
     def setup_class(cls):
+        helpers.reset_db()
         PylonsTestCase.setup_class()
         DguCreateTestData.create_dgu_test_data()
 
@@ -25,71 +49,96 @@ class TestLinkedUser(PylonsTestCase):
         user = 'nhseditor' # i.e. an official, needing anonymity to the public
         user_obj = model.User.by_name(unicode(user))
 
-        c.is_an_official = False
-        assert_equal(str(dgu_linked_user(user)),
-                '<a href="/publisher/national-health-service">National Health Service</a>')
-        assert_equal(str(dgu_linked_user(user_obj)),
-                '<a href="/publisher/national-health-service">National Health Service</a>')
+        with regular_user():
+            assert_equal(str(dgu_linked_user(user)),
+                    '<a href="/publisher/national-health-service">National Health Service</a>')
+            assert_equal(str(dgu_linked_user(user_obj)),
+                    '<a href="/publisher/national-health-service">National Health Service</a>')
 
-        c.is_an_official = True
-        assert_equal(str(dgu_linked_user(user)),
-                '<a href="/data/user/nhseditor">NHS Editor</a>')
-        assert_equal(str(dgu_linked_user(user_obj)),
-                '<a href="/data/user/nhseditor">NHS Editor</a>')
+        with publisher_user():
+            assert_equal(str(dgu_linked_user(user)),
+                    '<a href="/data/user/nhseditor">NHS Editor</a>')
+            assert_equal(str(dgu_linked_user(user_obj)),
+                    '<a href="/data/user/nhseditor">NHS Editor</a>')
+
+        with sysadmin_user():
+            assert_equal(str(dgu_linked_user(user)),
+                    '<a href="/data/user/nhseditor">NHS Editor</a>')
+            assert_equal(str(dgu_linked_user(user_obj)),
+                    '<a href="/data/user/nhseditor">NHS Editor</a>')
 
     def test_view_member_of_public(self):
         # most common case
         user = 'user_d102' # a member of the public, not anonymous - public comments
         user_obj = model.User.by_name(unicode(user))
 
-        c.is_an_official = False
-        assert_equal(str(dgu_linked_user(user)),
-                '<a href="/users/102">John Doe - a public user</a>')
-        assert_equal(str(dgu_linked_user(user_obj)),
-                '<a href="/users/102">John Doe - a public user</a>')
+        with regular_user():
+            assert_equal(str(dgu_linked_user(user)),
+                    '<a href="/users/102">John Doe - a public user</a>')
+            assert_equal(str(dgu_linked_user(user_obj)),
+                    '<a href="/users/102">John Doe - a public user</a>')
 
-        c.is_an_official = True
-        assert_equal(str(dgu_linked_user(user)),
-                '<a href="/users/102">John Doe - a public user</a>')
-        assert_equal(str(dgu_linked_user(user_obj)),
-                '<a href="/users/102">John Doe - a public user</a>')
+        with publisher_user():
+            assert_equal(str(dgu_linked_user(user)),
+                    '<a href="/users/102">John Doe - a public user</a>')
+            assert_equal(str(dgu_linked_user(user_obj)),
+                    '<a href="/users/102">John Doe - a public user</a>')
+
+        with sysadmin_user():
+            assert_equal(str(dgu_linked_user(user)),
+                    '<a href="/users/102">John Doe - a public user</a>')
+            assert_equal(str(dgu_linked_user(user_obj)),
+                    '<a href="/users/102">John Doe - a public user</a>')
 
     def test_view_sysadmin(self):
         # very common case
         user = 'sysadmin'
         user_obj = model.User.by_name(unicode(user))
 
-        c.is_an_official = False
-        assert_equal(str(dgu_linked_user(user)), 'System Administrator')
-        assert_equal(str(dgu_linked_user(user_obj)), 'System Administrator')
+        with regular_user():
+            assert_equal(str(dgu_linked_user(user)), 'System Administrator')
+            assert_equal(str(dgu_linked_user(user_obj)), 'System Administrator')
 
-        c.is_an_official = True
-        assert_equal(str(dgu_linked_user(user)),
-                '<a href="/data/user/sysadmin">Test Sysadmin</a>')
-        assert_equal(str(dgu_linked_user(user_obj)),
-                '<a href="/data/user/sysadmin">Test Sysadmin</a>')
+        with publisher_user():
+            assert_equal(str(dgu_linked_user(user)),
+                    '<a href="/data/user/sysadmin">Test Sysadmin</a>')
+            assert_equal(str(dgu_linked_user(user_obj)),
+                    '<a href="/data/user/sysadmin">Test Sysadmin</a>')
+
+        with sysadmin_user():
+            assert_equal(str(dgu_linked_user(user)),
+                    '<a href="/data/user/sysadmin">Test Sysadmin</a>')
+            assert_equal(str(dgu_linked_user(user_obj)),
+                    '<a href="/data/user/sysadmin">Test Sysadmin</a>')
 
     def test_view_non_object_user(self):
         # created by a script, but no User object exists
         user = 'random'
 
-        c.is_an_official = False
-        assert_equal(str(dgu_linked_user(user)), 'Staff')
+        with regular_user():
+            assert_equal(str(dgu_linked_user(user)), 'Staff')
 
-        c.is_an_official = True
-        assert_equal(str(dgu_linked_user(user)), 'random')
+        with publisher_user():
+            assert_equal(str(dgu_linked_user(user)), 'random')
+
+        with sysadmin_user():
+            assert_equal(str(dgu_linked_user(user)), 'random')
 
     def test_view_old_drupal_edit(self):
         # Up til Jun 2012, edits through drupal were saved like this
         # "NHS North Staffordshire (uid 6107 )"
         user = 'National Health Service (uid 101 )'
 
-        c.is_an_official = False
-        assert_equal(str(dgu_linked_user(user)),
+        with regular_user():
+            assert_equal(str(dgu_linked_user(user)),
                 '<a href="/publisher/national-health-service">National Health Service</a>')
 
-        c.is_an_official = True
-        assert_equal(str(dgu_linked_user(user)),
+        with publisher_user():
+            assert_equal(str(dgu_linked_user(user)),
+                '<a href="/data/user/user_d101">NHS Editor imported f...</a>')
+
+        with sysadmin_user():
+            assert_equal(str(dgu_linked_user(user)),
                 '<a href="/data/user/user_d101">NHS Editor imported f...</a>')
 
     def test_view_system_user(self):
@@ -97,11 +146,15 @@ class TestLinkedUser(PylonsTestCase):
         user_dict = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
         user = user_dict['name']
 
-        c.is_an_official = False
-        assert_equal(str(dgu_linked_user(user)), 'System Process')
+        with regular_user():
+            assert_equal(str(dgu_linked_user(user)), 'System Process')
 
-        c.is_an_official = True
-        assert_equal(str(dgu_linked_user(user, maxlength=100)),
+        with publisher_user():
+            assert_equal(str(dgu_linked_user(user, maxlength=100)),
+                '<a href="/data/user/test.ckan.net">System Process (Site user)</a>')
+
+        with sysadmin_user():
+            assert_equal(str(dgu_linked_user(user, maxlength=100)),
                 '<a href="/data/user/test.ckan.net">System Process (Site user)</a>')
 
 


### PR DESCRIPTION
Because most of our templates are now jinja2 c.is_an_official won't be set so
we need to call is_an_official() function instead.