### PR TITLE
Link to Drupal user page instead of CKAN user page

### DIFF
--- a/ckanext/dgu/lib/helpers.py
+++ b/ckanext/dgu/lib/helpers.py
@@ -339,12 +339,12 @@ def user_link_info(user_name, organization=None):  # Overwrite h.linked_user
                 name = 'System Process (%s)' % user_name
             else:
                 name = user.fullname or user.name
-            if type_ == 'official' or not user_drupal_id:
-                # officials use the CKAN user page for the time being (useful for debug)
+
+            if not user_drupal_id:
                 link_url = h.url_for(controller='user', action='read', id=user.name)
             else:
-                # Public use the Drupal user page.
                 link_url = '/users/%s' % user_drupal_id
+
             return (name, link_url)
         else:
             if type_ == 'system':

--- a/ckanext/dgu/tests/lib/test_helpers.py
+++ b/ckanext/dgu/tests/lib/test_helpers.py
@@ -135,11 +135,11 @@ class TestLinkedUser(PylonsTestCase):
 
         with publisher_user():
             assert_equal(str(dgu_linked_user(user)),
-                '<a href="/data/user/user_d101">NHS Editor imported f...</a>')
+                '<a href="/users/101">NHS Editor imported f...</a>')
 
         with sysadmin_user():
             assert_equal(str(dgu_linked_user(user)),
-                '<a href="/data/user/user_d101">NHS Editor imported f...</a>')
+                '<a href="/users/101">NHS Editor imported f...</a>')
 
     def test_view_system_user(self):
         # created on the API


### PR DESCRIPTION
As requested in ticket #279 link to the Drupal page where possible.