### PR TITLE
Fix links to Drupal users. 

### DIFF
--- a/ckanext/dgu/lib/helpers.py
+++ b/ckanext/dgu/lib/helpers.py
@@ -343,7 +343,7 @@ def user_link_info(user_name, organization=None):  # Overwrite h.linked_user
             if not user_drupal_id:
                 link_url = h.url_for(controller='user', action='read', id=user.name)
             else:
-                link_url = '/users/%s' % user_drupal_id
+                link_url = '/user/%s' % user_drupal_id
 
             return (name, link_url)
         else:

--- a/ckanext/dgu/tests/lib/test_helpers.py
+++ b/ckanext/dgu/tests/lib/test_helpers.py
@@ -74,21 +74,21 @@ class TestLinkedUser(PylonsTestCase):
 
         with regular_user():
             assert_equal(str(dgu_linked_user(user)),
-                    '<a href="/users/102">John Doe - a public user</a>')
+                    '<a href="/user/102">John Doe - a public user</a>')
             assert_equal(str(dgu_linked_user(user_obj)),
-                    '<a href="/users/102">John Doe - a public user</a>')
+                    '<a href="/user/102">John Doe - a public user</a>')
 
         with publisher_user():
             assert_equal(str(dgu_linked_user(user)),
-                    '<a href="/users/102">John Doe - a public user</a>')
+                    '<a href="/user/102">John Doe - a public user</a>')
             assert_equal(str(dgu_linked_user(user_obj)),
-                    '<a href="/users/102">John Doe - a public user</a>')
+                    '<a href="/user/102">John Doe - a public user</a>')
 
         with sysadmin_user():
             assert_equal(str(dgu_linked_user(user)),
-                    '<a href="/users/102">John Doe - a public user</a>')
+                    '<a href="/user/102">John Doe - a public user</a>')
             assert_equal(str(dgu_linked_user(user_obj)),
-                    '<a href="/users/102">John Doe - a public user</a>')
+                    '<a href="/user/102">John Doe - a public user</a>')
 
     def test_view_sysadmin(self):
         # very common case
@@ -135,11 +135,11 @@ class TestLinkedUser(PylonsTestCase):
 
         with publisher_user():
             assert_equal(str(dgu_linked_user(user)),
-                '<a href="/users/101">NHS Editor imported f...</a>')
+                '<a href="/user/101">NHS Editor imported f...</a>')
 
         with sysadmin_user():
             assert_equal(str(dgu_linked_user(user)),
-                '<a href="/users/101">NHS Editor imported f...</a>')
+                '<a href="/user/101">NHS Editor imported f...</a>')
 
     def test_view_system_user(self):
         # created on the API


### PR DESCRIPTION
I got it wrong last year, but only noticed this week when we used the link for publishers (there were no links to non-publishers until then actually).