### PR TITLE
More sane publisher handling for package edit

### DIFF
--- a/ckanext/dgu/theme/templates/publisher/read.html
+++ b/ckanext/dgu/theme/templates/publisher/read.html
@@ -215,7 +215,7 @@
                 {% endif %}
                 {% if packagecreate %}
                   <li>
-                    <a href="{{ h.url_for('dataset_new') }}?owner_org={{ c.group.name }}"><span class="wrap-icon"><i class="icon-plus-sign-alt"></i> </span>Add a new dataset &raquo;</a>
+                    <a href="{{ h.url_for('dataset_new') }}?owner_org={{ c.group.id }}"><span class="wrap-icon"><i class="icon-plus-sign-alt"></i> </span>Add a new dataset &raquo;</a>
                   </li>
                 {% endif %}
                 {% if organizationupdate %}


### PR DESCRIPTION
This PR changes the Add new dataset link to use the ID, which is
what the controller expects - and also for users in only a single org,
will preselect that org.

This should fix #233