### PR TITLE
Re-enable Solr search operators.

### DIFF
--- a/ckanext/dgu/lib/search.py
+++ b/ckanext/dgu/lib/search.py
@@ -5,7 +5,7 @@ import re
 # the individual ampersand and pipe chars.
 # Also, we're not going to escape backslashes!
 # http://lucene.apache.org/core/4_0_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Escaping%20Special%20Characters
-ESCAPE_CHARS_RE = re.compile(r'(?<!\\)(?P<char>[&|+\-!(){}[\]^"~*?:/])')
+ESCAPE_CHARS_RE = re.compile(r'(?<!\\)(?P<char>[&|\!(){}[\]^"~*?:/])')
 
 def solr_escape(value):
     r"""Escape un-escaped special characters and return escaped value.


### PR DESCRIPTION
This commit re-enables - and + as options to search terms. Solr only
interprets them if they are at the start of a word and not part of a
composite.

family -planning works, family-planning also works but doesn't apply the
-.  A - by itself in the middle of a sentence 'LIDAR Composite DSM - 1m'
is just ignored.

This should fix #306 