### PR TITLE
Replace API dropdown with icon because ...

### DIFF
--- a/ckanext/dgu/theme/src/css/dgu-ckan.less
+++ b/ckanext/dgu/theme/src/css/dgu-ckan.less
@@ -20,11 +20,10 @@
 }
 
 .api-icon {
-  font-size: 1.7em; font-weight: bold;
+  font-weight: bold;
 }
 .api-chevron {
-  margin-left: 16px !important;
-  margin-top: -2px !important;
+  margin-left: 8px !important;
 }
 
 .inline-icon {

--- a/ckanext/dgu/theme/templates/package/read_common.html
+++ b/ckanext/dgu/theme/templates/package/read_common.html
@@ -38,12 +38,14 @@
         </span>
         {% endif %}
       <span class="dropdown">
-        <a href="#" class="js-tooltip dropdown-button" data-placement="top" data-delay="300" data-toggle="dropdown" title="" data-original-title="API">
-          <span class="api-icon">API</span>
+        <a href="#" class="js-tooltip dropdown-button" data-placement="top" data-delay="300" data-toggle="dropdown" title="" data-original-title="Metadata&nbsp;API">
+          <span class="api-icon">
+              <i class="icon-code icon-2x"></i>
+          </span>
           <div class="dropdown-chevron api-chevron" ></div>
         </a>
         <div class="panel panel-default dropdown-menu" role="menu" aria-labelledby="dLabel">
-          <div class="panel-heading">API</div>
+          <div class="panel-heading">Metadata API</div>
           <div class="panel-body">
             <p>The information on this page (the dataset metadata) is also available in JSON format.</p>
             <ul>


### PR DESCRIPTION
.. it'll be confusing when we put the API block next to the datapackage
block.

Requires grunt to be run.

This should fix #324 but should probably wait until #309 is also done