### PR TITLE
Promotes NII datasets to top of search results.

### DIFF
--- a/ckanext/dgu/plugin.py
+++ b/ckanext/dgu/plugin.py
@@ -459,7 +459,8 @@ class SearchPlugin(p.SingletonPlugin):
         # Set the 'qf' (queryfield) parameter to a fixed list of boosted solr fields
         # tuned for DGU. If a dismax query is run, then these will be the fields that are searched
         # within.
-        search_params['qf'] = 'title^4 name^3 notes^2 text tags^0.3 group_titles^0.3 extras_harvest_document_content^0.2'
+        search_params['qf'] = 'title^4 name^3 notes^2 text group_titles^0.3 extras_harvest_document_content^0.2'
+        search_params['bf'] = 'core_dataset^10000'
 
         # ignore dataset_type:dataset which CKAN2 adds in - we dont use
         # dataset_type and it mucks up spatial search

--- a/config/solr/schema-2.0-dgu.xml
+++ b/config/solr/schema-2.0-dgu.xml
@@ -96,7 +96,7 @@
     <field name="organization" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="organization_titles" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="unpublished" type="boolean" indexed="true" stored="true" multiValued="true"/>
-    <field name="core_dataset" type="boolean" indexed="true" stored="true" multiValued="true"/>
+    <field name="core_dataset" type="boolean" indexed="true" stored="true" multiValued="false"/>
     <field name="api" type="boolean" indexed="true" stored="true" multiValued="true"/>
     <field name="publish_restricted" type="boolean" indexed="true" stored="true" multiValued="true"/>
 


### PR DESCRIPTION
Boosts core_dataset=true to top of the search results using a
scientifically determined number to mimic 'sponsored results' without
breaking the solrconfig.xml with more settings.

Note this modifies the schema.xml to ensure core_data is not multivalued (we only ever have one value for it).  Fixes #330 