### PR TITLE
Dumps improved

### DIFF
--- a/ckanext/dgu/bin/gov_daily.py
+++ b/ckanext/dgu/bin/gov_daily.py
@@ -299,7 +299,7 @@ def command(config_file):
         arguments['--remote'] = config['ckan.site_url']
         arguments['--get-request'] = True
         dump_datasets(
-            'v2.json', ckanapi.cli.dump.dump_things, 2,
+            'v2.jsonl', ckanapi.cli.dump.dump_things, 2,
             ckan, 'datasets', arguments,
             worker_pool=None, stdout=devnull, stderr=devnull)
         report_time_taken(log)

--- a/ckanext/dgu/bin/gov_daily.py
+++ b/ckanext/dgu/bin/gov_daily.py
@@ -279,6 +279,13 @@ def command(config_file):
         report_time_taken(log)
 
     if run_task('dump-json2'):
+        # since gov_daily.py is run with sudo, and a path to python in the venv
+        # rather than in an activated environment, and ckanapi creates
+        # subprocesses, we need to activate the environment. The same one as
+        # our current python interpreter.
+        bin_dir = os.path.dirname(sys.executable)
+        activate_this = os.path.join(bin_dir, 'activate_this.py')
+        execfile(activate_this, dict(__file__=activate_this))
         import ckanapi.cli.dump
         log.info('Creating database dumps - JSON 2')
         create_dump_dir_if_necessary()
@@ -290,6 +297,7 @@ def command(config_file):
         #arguments['ID_OR_NAME'] = ['mot-active-vts', 'road-accidents-safety-data']
         arguments['--processes'] = 4
         arguments['--remote'] = config['ckan.site_url']
+        arguments['--get-request'] = True
         dump_datasets(
             'v2.json', ckanapi.cli.dump.dump_things, 2,
             ckan, 'datasets', arguments,

--- a/ckanext/dgu/lib/dumper.py
+++ b/ckanext/dgu/lib/dumper.py
@@ -112,6 +112,7 @@ class CSVDumper(object):
             # TODO Get a better list of fields to dump than just what we see in
             # the first dataset...
             self.dataset_keys = sorted(pkg_dict.keys())
+            self.dataset_keys.remove('license')  # duplicate
             self.write_header(self.dataset_keys)
 
         url = config.get('ckan.site_url')

--- a/ckanext/dgu/lib/inventory.py
+++ b/ckanext/dgu/lib/inventory.py
@@ -6,15 +6,15 @@ from ckanext.dgu.plugins_toolkit import (c, NotAuthorized,
     ValidationError, get_action, check_access)
 from ckan.lib.search import SearchIndexError
 
-def inventory_dumper(tmpfile, query):
-    """ Dumps all of the inventory items to the open tmpfile using the
+def unpublished_dumper(tmpfile, query):
+    """ Dumps all of the unpublished items to the open tmpfile using the
         packages provided by query """
     import csv
     import dateutil.parser
 
     writer = csv.writer(tmpfile)
     writer.writerow(["Name", "Description", "Department", "Publish date", "Release notes"])
-    for pkg in query.all():
+    for pkg in query.yield_per(200):
         if not pkg.extras.get('unpublished', False):
             continue
 


### PR DESCRIPTION
* new json dump added - with extension `.v2.jsonl` - using 'ckanapi dump'. Provides 'validated' (API v3) version of each dataset (the existing json was the unvalidated one), so includes full details of the organization, plus results of the archival & qa. Also benefits from being json lines format, so you don't need to load the whole thing into memory. jq use is still ok, just with [different syntax](http://jsonlines.org/examples/).
* reduced memory requirements - previously 2 of the 3 dumps would fail on a machine with 4GB, but they all run on that now
