### PR TITLE
Cached resources disable

### DIFF
--- a/ckanext/dgu/controllers/data.py
+++ b/ckanext/dgu/controllers/data.py
@@ -266,6 +266,7 @@ class DataController(BaseController):
         set a <base> header if not present to make sure all relative links are
         resolved correctly.
         """
+        abort(403, 'This feature is currently disabled')
         from pylons import response
         from paste.fileapp import FileApp
         from ckanext.dgu.lib.helpers import tidy_url

--- a/ckanext/dgu/theme/src/scripts/recline_pack/dgu-recline-integration.js
+++ b/ckanext/dgu/theme/src/scripts/recline_pack/dgu-recline-integration.js
@@ -180,7 +180,7 @@ CKAN.Dgu.resourcePreviewer = (function($,my) {
         my.showPlainTextData(data);
       });
     }
-    else if (resourceData.formatNormalized in {'html':'', 'htm':''}
+    /*else if (resourceData.formatNormalized in {'html':'', 'htm':''}
         ||  resourceData.url.substring(0,23)=='http://docs.google.com/') {
       // we displays a fullscreen dialog with the url in an iframe.
       my.$dialog().empty();
@@ -191,7 +191,7 @@ CKAN.Dgu.resourcePreviewer = (function($,my) {
       // Change this to be a specific element for #977
       $('#ckanext-html-preview').append(el);
       //my.$dialog().append(el);
-    }
+    }*/
     // images
     else if (resourceData.formatNormalized in {'png':'', 'jpg':'', 'gif':''}
         ||  resourceData.resource_type=='image') {

--- a/ckanext/dgu/theme/templates/package/read.html
+++ b/ckanext/dgu/theme/templates/package/read.html
@@ -113,7 +113,7 @@
 
     {% set publisher_name = c.pkg.get_organization().name %}
     {% set issue_count = h.get_issue_count(c.pkg.id) %}
-
+{# Disabled
     {% if not h.is_unpublished_item(c.pkg_dict) %}
       <h2>Data Package</h2>
       {% if h.packagezip_has_data(c.pkg) == None %}
@@ -167,6 +167,7 @@
           </div>
       {% endif %}
     {% endif %}
+#}
 
       <div class="dataset-resources">
         <!-- Resources -->

--- a/ckanext/dgu/theme/templates/package/resource_read.html
+++ b/ckanext/dgu/theme/templates/package/resource_read.html
@@ -78,7 +78,7 @@
         {% endif %}
       </a>
       {% endif %}
-
+{# Disabled
       {% set cache_url, cache_timestamp = h.get_cache(c.resource) %}
       {% if cache_url and not h.get_resource_wms(c.resource) %}
        <a class="btn btn-danger resource-url-analytics resource-type-{{c.resource.get('resource_type')}}" href="{{cache_url}}" onclick="{{m.download_tracker(c.resource, c.pkg_dict, publisher.name, 'download-cache') }}">
@@ -87,6 +87,7 @@
         </div>
        </a>
        {% endif %}
+#}
       {% endwith %}
 
       {% if h.is_wms(c.resource) %}


### PR DESCRIPTION
Prevents cached resources surfacing in 5 places.

* resource page - cached download link
* resource page - cached download /data/resource_cache/e4/e41845a7-1863-45cf-858d-030265be73c0/ha-roadworks_2011_12_28.xml
* dataset page - package zip download link
* dataset page - package zip download /dataset/staff-organograms-and-pay-treasury-solicitors-department/datapackage.zip
* preview of html /dataset/land-registry-monthly-price-paid-data/resource/a65d1a6c-1c91-49e5-852a-8e495bce9bff

This PR is in concert with changes to ckanext-packagezip and nginx config