### PR TITLE
Modifications for ITS EU Directive.

### DIFF
--- a/ckanext/dgu/forms/dataset_form.py
+++ b/ckanext/dgu/forms/dataset_form.py
@@ -285,6 +285,7 @@ class DatasetForm(p.SingletonPlugin):
 
             'unpublished': [ignore_missing, bool_, convert_to_extras],
             'core-dataset': [ignore_missing, bool_, convert_to_extras],
+            'its-dataset': [ignore_missing, bool_, convert_to_extras],
             'release-notes': [ignore_missing, unicode, convert_to_extras],
             'publish-date': [ignore_missing, date_to_db, convert_to_extras],
             'publish-restricted': [ignore_missing, bool_, convert_to_extras],
@@ -346,6 +347,7 @@ class DatasetForm(p.SingletonPlugin):
 
             'unpublished': [convert_from_extras, ignore_missing],
             'core-dataset': [convert_from_extras, ignore_missing],
+            'its-dataset': [convert_from_extras, ignore_missing],
             'release-notes': [convert_from_extras, ignore_missing],
             'publish-date': [convert_from_extras, ignore_missing, date_to_form],
             'publish-restricted': [convert_from_extras, ignore_missing],

--- a/ckanext/dgu/lib/helpers.py
+++ b/ckanext/dgu/lib/helpers.py
@@ -2057,6 +2057,16 @@ def is_core_dataset(package):
 
     return False
 
+def is_its_dataset(package):
+    from paste.deploy.converters import asbool
+    v = get_from_flat_dict(package['extras'], 'its-dataset')
+    try:
+        return asbool(v)
+    except:
+        pass
+
+    return False
+
 def report_generated_at(reportname, object_id='__all__', withsub=False):
     from ckan import model
     from ckanext.report.model import DataCache

--- a/ckanext/dgu/plugin.py
+++ b/ckanext/dgu/plugin.py
@@ -518,6 +518,7 @@ class SearchPlugin(p.SingletonPlugin):
         SearchIndexing.add_field__openness(pkg_dict)
         SearchIndexing.add_popularity(pkg_dict)
         SearchIndexing.add_inventory(pkg_dict)
+        SearchIndexing.add_its(pkg_dict)
         SearchIndexing.add_api_flag(pkg_dict)
         SearchIndexing.add_theme(pkg_dict)
         if is_plugin_enabled('dgu_schema'):

--- a/ckanext/dgu/search_indexing.py
+++ b/ckanext/dgu/search_indexing.py
@@ -37,6 +37,11 @@ class SearchIndexing(object):
         log.debug('API: %s', pkg_dict['api'])
 
     @classmethod
+    def add_its(cls, pkg_dict):
+        pkg_dict['its_dataset'] = pkg_dict.get('its-dataset', False)
+        log.debug('ITS: %s', pkg_dict['its_dataset'])
+
+    @classmethod
     def add_inventory(cls, pkg_dict):
         ''' Sets unpublished to false if not present and also states whether the item is marked
             as never being published. '''
@@ -44,7 +49,7 @@ class SearchIndexing(object):
         #log.debug('Unpublished: %s', pkg_dict['unpublished'])
 
         pkg_dict['core_dataset'] = pkg_dict.get('core-dataset', False)
-        #log.debug('NII: %s', pkg_dict['core_dataset'])
+        log.debug('NII: %s', pkg_dict['core_dataset'])
 
         # We also need to mark whether it is restricted (as in it will never be
         # released).
@@ -57,6 +62,8 @@ class SearchIndexing(object):
 
         if asbool(pkg_dict.get('core-dataset', False)):
             pkg_dict['collection'].append('National Information Infrastructure')
+        if asbool(pkg_dict.get('its-dataset', False)):
+            pkg_dict['collection'].append('Intelligent Transport Systems')
         if dgu_helpers.is_dataset_organogram(pkg_dict):
             pkg_dict['collection'].append('Organogram')
 

--- a/ckanext/dgu/theme/templates/package/edit_form.html
+++ b/ckanext/dgu/theme/templates/package/edit_form.html
@@ -744,6 +744,24 @@ Passed in:
       <p class="instructions further">NII datasets are determined by their publishers to be nationally important, and publishers agree to the higher level of publishing quality described in the NII literature.</p>
     </div>
 
+    <div class="well">
+      <h3>Intelligent Transport Systems</h3>
+      <div class="form-group">
+          <label class="control-label" style="font-weight: normal;">
+            <div class="controls">
+              <div class="checkbox">
+                {# When submitting a non-validated form, and you uncheck the box, then you need it to submit a value, or it will be overwritten in the controller by the saved value, so we use a hidden field of the same name. There is JS at the bottom that deletes one of the checkboxes, so that only one is submitted. #}
+                <input id="its-dataset-hidden" name="its-dataset" type="hidden" value=""/>
+                <input id="its-dataset" name="its-dataset" type="checkbox" value="true"
+                {% if data.get('its-dataset', '').lower() == 'true' %} checked="checked"{% endif %} />
+                An Intelligent Transport Systems dataset
+              </div>
+            </div>
+          </label>
+      </div>
+      <p class="instructions further">You should check this box if the dataset is a part of the Intelligent Transport Systems EU Directive (2010/40/EU)</p>
+    </div>
+
 </fieldset>
 
 <fieldset class="tab-pane boxed whitebox fade" id="section-temporal-field">
@@ -1043,6 +1061,9 @@ $(function() {
     }
     if ($("#core-dataset").prop("checked")) {
       $("#core-dataset-hidden").prop("disabled", true);
+    }
+    if ($("#its-dataset").prop("checked")) {
+      $("#its-dataset-hidden").prop("disabled", true);
     }
   });
 });

--- a/config/solr/schema-2.0-dgu.xml
+++ b/config/solr/schema-2.0-dgu.xml
@@ -100,6 +100,7 @@
 
     <field name="unpublished" type="boolean" indexed="true" stored="true" multiValued="true"/>
     <field name="core_dataset" type="boolean" indexed="true" stored="true" multiValued="false"/>
+    <field name="its_dataset" type="boolean" indexed="true" stored="true" multiValued="false"/>
     <field name="api" type="boolean" indexed="true" stored="true" multiValued="true"/>
     <field name="publish_restricted" type="boolean" indexed="true" stored="true" multiValued="true"/>
     <field name="all_themes" type="string" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
Adds a checkbox close to the NII checkbox to make ITS datasets.  These
datasets are then shown as a facet in the Collections section of the
search page.

Includes a modification to the Solr schema so you need to make sure it
is updated (if it isn't already linked).

Expecting content changes tomorrow, so not yet ready to merge.