### PR TITLE
Fix for old dataset views

### DIFF
--- a/ckanext/dgu/lib/helpers.py
+++ b/ckanext/dgu/lib/helpers.py
@@ -43,6 +43,10 @@ def is_resource_broken(resource):
     archival = resource.get('archiver')
     if not archival:
         return None # don't know
+    if not isinstance(archival, dict):
+        # some old versions of datasets are incorrectly stored as strings
+        # eg /dataset/financial-transactions-data-defra%402016-10-24T14%3A43%3A49.461399
+        return None
     return archival.get('is_broken')
 
 def _is_additional_resource(resource):
@@ -547,13 +551,19 @@ def ga_package_zip_resource(pkg, pkg_dict):
 
 
 def ga_download_tracking_data(resource, pkg_dict, publisher_name, action='download'):
+    qa = resource.get('qa') or {}
+    if not isinstance(qa, dict):
+        qa = {}
+    archiver = (resource.get('archiver') or {})
+    if not isinstance(archiver, dict):
+        archiver = {}
     resource_dimensions = dict(
         dimension4=publisher_name,
         dimension5=resource.get('format'),
         dimension6=resource.get('date') or '',
-        dimension7=(resource.get('qa') or {}).get('openness_score', ''),
-        dimension8=(pkg_dict.get('qa') or {}).get('openness_score', ''),
-        dimension9=(resource.get('archiver') or {}).get('is_broken', ''),
+        dimension7=qa.get('openness_score', ''),
+        dimension8=qa.get('openness_score', ''),
+        dimension9=archiver.get('is_broken', ''),
     )
     return resource_dimensions, action, resource.get('url')
 

--- a/ckanext/dgu/theme/templates/package/read.html
+++ b/ckanext/dgu/theme/templates/package/read.html
@@ -337,8 +337,9 @@
             {% with %}
             {% set is_location_data = h.is_location_data(c.pkg_dict) %}
             {% set gemini = res.get('gemini',False) %} {# i.e. the gemini metadata links, shown as resources #}
-            {% set is_download = not is_location_data and res.get('resource_type') != 'api' and (res.format or '').upper() not in non_download_formats and res.get('archiver', {}).get('format') not in non_download_formats %}
-            {% set is_html = not is_download and (res.format == 'HTML' or res.get('archiver', {}).get('format') == 'HTML') %}
+            {% set archiver = res['archiver'] if res.get('archiver') and res['archiver'] is not string else {} %}
+            {% set is_download = not is_location_data and res.get('resource_type') != 'api' and (res.format or '').upper() not in non_download_formats and archiver.get('format') not in non_download_formats %}
+            {% set is_html = not is_download and (res.format == 'HTML' or archiver.get('format') == 'HTML') %}
             <span>
               {# exclamation mark #}
               {% if h.is_resource_broken(res) %}
@@ -367,7 +368,7 @@
                     {{ res.format }}
                   {% endif %}
                 </strong>
-                {% if is_download and res.get('archiver') and res['archiver'].get('size') %}
+                {% if is_download and archiver and res['archiver'].get('size') %}
                   ({{ res['archiver']['size']|filesizeformat }})
                 {% endif %}
               </a>


### PR DESCRIPTION
Fix for displaying dataset when archiver was accidentally stored as a string

eg /dataset/financial-transactions-data-defra%402016-10-24T14%3A43%3A49.461399