### PR TITLE
Remove unneeded menu links

### DIFF
--- a/ckanext/dgu/theme/templates/header.html
+++ b/ckanext/dgu/theme/templates/header.html
@@ -99,7 +99,6 @@
         <li><a class="subnav-item subnav-data-item {{ 'active' if url.startswith('/data/map-based-search') }}" href="/data/map-based-search">Map Search</a></li>
         <li><a class="subnav-item subnav-data-item" href="/data-request">Data Requests</a></li>
         <li><a class="subnav-item subnav-data-item {{ 'active' if url.startswith('/publisher') }}" href="/publisher">Publishers</a></li>
-        <li><a class="subnav-item subnav-data-item" href="https://data.gov.uk/data/api">Data API</a></li>
         <li><a class="subnav-item subnav-data-item" href="/organogram/cabinet-office">Organograms</a></li>
         {#
         {% if h.config_get('dgu.openspending_reports_enabled') %}
@@ -122,10 +121,7 @@
 
       <ul class="subnav subnav-interact">
         <li><a class="subnav-item subnav-interact-item" href="/location">Location</a></li>
-        <li><a class="subnav-item subnav-interact-item" href="/blog">Blogs</a></li>
-        <li><a class="subnav-item subnav-interact-item" href="/forum">All Forums</a></li>
         <li><a class="subnav-item subnav-interact-item" href="/library">Library</a></li>
-        <li><a class="subnav-item subnav-interact-item" href="/search/everything">Search content</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Already removed from Drupal menus, so this is to make all menus consistent