### PR TITLE
Change where publishers link to.

### DIFF
--- a/ckanext/dgu/theme/templates/publisher/index.html
+++ b/ckanext/dgu/theme/templates/publisher/index.html
@@ -58,7 +58,7 @@
             <button class="btn btn-xs btn-default js-collapse"><i class="icon icon-minus"></i></button>
           {% endif %}
           <div class="publisher-row {% if closed %}closed{% endif %}">
-            <a href="/publisher/{{ pub['name'] }}">
+            <a href="/search?q=&filters[publisher]={{ pub['title'] }}">
               {{ pub['title'] }}
               {% if publisher_abbreviations.get(pub['id']) %}
                 ({{ publisher_abbreviations.get(pub['id']) }})


### PR DESCRIPTION
When visiting /publisher, we want the links to go to github.com/alphagov/datagovuk_find and to apply a filter where the selected publisher is active.