### PR TITLE
Redirect search from publisher index page

### DIFF
--- a/ckanext/dgu/theme/templates/publisher/read.html
+++ b/ckanext/dgu/theme/templates/publisher/read.html
@@ -228,7 +228,7 @@
 
     {% call m.search_form(
         placeholder='Search publisher',
-        set_fields={'publisher':c.group.name},
+        set_fields={'publisher':c.group.title},
       ) %}
       <label class="checkbox" id="publisher-extra-options">
         <input type="checkbox" name="publisher-results-include-subpub" class="inline" />


### PR DESCRIPTION
When visiting /publisher/slug we want the search to redirect to /search
using the publisher title (rather than publisher name).