### PR TITLE
Add licence file, as specified in the readme

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,15 @@
+(C) Crown Copyright 2018
+Copyright (C) 2010-2012 Open Knowledge Foundation
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Note, it's probably easiest just to mention AGPL in this file, as its probably only partially OGL licensed. And this file is designed to be machine-readable (e.g. for GitHub's licence section & API) so adding multiple ones is just going to confuse things, for v. limited benefit to anyone.